### PR TITLE
Fix Window constructor parameter name inconsistency

### DIFF
--- a/Sparky-core/src/graphics/window.h
+++ b/Sparky-core/src/graphics/window.h
@@ -21,7 +21,7 @@ namespace sparky { namespace graphics {
 		bool m_MouseButtons[MAX_BUTTONS];
 		double mx, my;
 	public:
-		Window(const char *name, int width, int height);
+		Window(const char *title, int width, int height);
 		~Window();
 		void clear() const;
 		void update();


### PR DESCRIPTION
Changed the parameter named "name" in the Windows constructor to "title" to be consistent with the member variable names.
