### PR TITLE
Added the missing z & w initialization in the vec 4 constructor

### DIFF
--- a/Sparky-core/src/maths/vec4.cpp
+++ b/Sparky-core/src/maths/vec4.cpp
@@ -6,6 +6,8 @@ namespace sparky { namespace maths {
 	{
 		x = 0.0f;
 		y = 0.0f;
+		z = 0.0f;
+		w = 0.0f;
 	}
 
 	vec4::vec4(const float& x, const float& y, const float& z, const float& w)


### PR DESCRIPTION
Hello,

I noticed you forgot to init the z & w parameter in the vec 4 constructor.

Keep up the good work !
