### PR TITLE
STRINGFORMAT_BUFFER_SIZE as constexpr

### DIFF
--- a/Sparky-core/src/sp/String.h
+++ b/Sparky-core/src/sp/String.h
@@ -8,7 +8,7 @@ typedef std::string String;
 
 namespace sp {
 
-#define STRINGFORMAT_BUFFER_SIZE 10 * 1024
+	constexpr auto STRINGFORMAT_BUFFER_SIZE  { 10 * 1024 };
 
 	class SP_API StringFormat
 	{

--- a/Sparky-core/src/sp/String.h
+++ b/Sparky-core/src/sp/String.h
@@ -8,7 +8,7 @@ typedef std::string String;
 
 namespace sp {
 
-	constexpr auto STRINGFORMAT_BUFFER_SIZE  { 10 * 1024 };
+	constexpr int STRINGFORMAT_BUFFER_SIZE  { 10 * 1024 };
 
 	class SP_API StringFormat
 	{


### PR DESCRIPTION
proposal: changing  #defines Which contains math operations to ' constexpr ' (compile-time variable).
