### PR TITLE
Fix issue #76, pressing "R" with DirectX no longer crashing

### DIFF
--- a/Sparky-core/src/sp/platform/directx/DXShader.cpp
+++ b/Sparky-core/src/sp/platform/directx/DXShader.cpp
@@ -10,6 +10,28 @@
 namespace sp { namespace graphics { namespace API {
 
 	const D3DShader* D3DShader::s_CurrentlyBound = nullptr;
+#if 1
+	bool D3DShader::TryCompile(const String& source, String& error)
+	{
+		const D3DShader* currentBound = s_CurrentlyBound;
+		HRESULT result = S_FALSE;
+		if ( Compile(source, "vs_4_0", "VSMain") )
+		{
+			if ( Compile(source, "ps_4_0", "PSMain") )
+			{
+				result = D3DContext::GetDevice()->CreateVertexShader(currentBound->m_Data.vs->GetBufferPointer(), currentBound->m_Data.vs->GetBufferSize(), NULL, &currentBound->m_Data.vertexShader);
+				result &= D3DContext::GetDevice()->CreatePixelShader(currentBound->m_Data.ps->GetBufferPointer(), currentBound->m_Data.ps->GetBufferSize(), NULL, &currentBound->m_Data.pixelShader);
+			}
+		}
+		return result == S_OK ? true : false;
+	}
+
+	bool D3DShader::TryCompileFromFile(const String& filepath, String& error)
+	{
+		String source = utils::ReadFile(filepath);
+		return TryCompile(source, error);
+	}
+#endif
 
 	D3DShader::D3DShader(const String& name, const String& source)
 		: m_Name(name)

--- a/Sparky-core/src/sp/platform/directx/DXShader.h
+++ b/Sparky-core/src/sp/platform/directx/DXShader.h
@@ -65,7 +65,7 @@ namespace sp { namespace graphics { namespace API {
 		inline const ShaderUniformBufferDeclaration* GetPSUserUniformBuffer() const override { return m_PSUserUniformBuffer; }
 		inline const ShaderResourceList& GetResources() const override { return m_Resources; }
 	private:
-		ID3DBlob* Compile(const String& source, const String& profile, const String& main);
+		static ID3DBlob* Compile(const String& source, const String& profile, const String& main);
 		void Load(const String& source);
 
 		String RemoveComments(const String& source);
@@ -78,6 +78,8 @@ namespace sp { namespace graphics { namespace API {
 		void CreateBuffers();
 		ShaderStruct* FindStruct(const String& name);
 	public:
+		static bool TryCompile(const String& source, String& error);
+		static bool TryCompileFromFile(const String& filepath, String& error);
 		static D3DShader* FromFile(const String& name, const String& filepath, void* address);
 		static D3DShader* FromSource(const String& name, const String& source);
 	public:


### PR DESCRIPTION
I'm not sure that the function is doing the right thing, so please check it but the crash isn't here anymore.
