### PR TITLE
Support to toggle vsync

### DIFF
--- a/Sparky-core/src/sp/app/Window.cpp
+++ b/Sparky-core/src/sp/app/Window.cpp
@@ -2,6 +2,7 @@
 #include "Window.h"
 
 #include "sp/graphics/Renderer.h"
+#include "sp/graphics/API/Context.h"
 
 #include "sp/utils/Log.h"
 
@@ -57,11 +58,6 @@ namespace sp {
 		return true;
 	}
 	
-	void Window::SetVsync(bool enabled)
-	{
-		// TODO: Not implemented
-		m_Vsync = enabled;
-	}
 
 	void Window::Clear() const
 	{

--- a/Sparky-core/src/sp/platform/directx/DXContext.cpp
+++ b/Sparky-core/src/sp/platform/directx/DXContext.cpp
@@ -28,6 +28,7 @@ namespace sp { namespace graphics { namespace API {
 	void D3DContext::InitD3D(HWND hWnd)
 	{
 		m_MSAAEnabled = true;
+		m_Vsync = true;
 
 		HRESULT hr = D3D11CreateDevice(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, D3D11_CREATE_DEVICE_DEBUG, NULL, NULL, D3D11_SDK_VERSION, &dev, &m_D3DFeatureLevel, &devcon);
 		dev->CheckMultisampleQualityLevels(DXGI_FORMAT_R8G8B8A8_UNORM, 4, &m_MSAAQuality);
@@ -146,7 +147,7 @@ namespace sp { namespace graphics { namespace API {
 
 	void D3DContext::Present()
 	{
-		swapchain->Present(0, 0);
+		swapchain->Present(m_Vsync, 0);
 	}
 
 	String D3DContext::GetD3DVersionStringInternal() const

--- a/Sparky-core/src/sp/platform/directx/DXContext.h
+++ b/Sparky-core/src/sp/platform/directx/DXContext.h
@@ -16,6 +16,7 @@ namespace sp { namespace graphics { namespace API {
 		D3D_FEATURE_LEVEL m_D3DFeatureLevel;
 		uint m_MSAAQuality;
 		bool m_MSAAEnabled;
+		bool m_Vsync;
 
 		ID3D11RenderTargetView* m_RenderTargetView;
 		ID3D11DepthStencilView* m_DepthStencilView;
@@ -38,6 +39,8 @@ namespace sp { namespace graphics { namespace API {
 
 		String GetD3DVersionStringInternal() const;
 	public:
+		inline static void SetVsync(bool vsync) { Get()->m_Vsync = vsync; }
+
 		inline static D3DContext* GetContext() { return (D3DContext*)s_Context; }
 
 		inline static IDXGISwapChain* GetSwapChain() { return GetContext()->swapchain; }

--- a/Sparky-core/src/sp/platform/windows/Win32Window.cpp
+++ b/Sparky-core/src/sp/platform/windows/Win32Window.cpp
@@ -12,6 +12,7 @@
 #include "sp/graphics/Renderer.h"
 
 #include <GL/glew.h>
+#include <GL/wglew.h>
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
@@ -129,6 +130,14 @@ namespace sp {
 	{
 		m_Properties.title = title + "  |  Renderer: " + Renderer::GetTitle();
 		SetWindowText(hWnd, m_Properties.title.c_str());
+	}
+
+	void Window::SetVsync(bool enabled) {
+		// TODO: Not implemented
+		m_Vsync = enabled;
+		if (graphics::API::Context::GetRenderAPI() == graphics::API::RenderAPI::OPENGL) {
+			wglSwapIntervalEXT(m_Vsync);
+		}
 	}
 
 	void ResizeCallback(Window* window, int32 width, int32 height)

--- a/Sparky-core/src/sp/platform/windows/Win32Window.cpp
+++ b/Sparky-core/src/sp/platform/windows/Win32Window.cpp
@@ -11,6 +11,8 @@
 #include "sp/graphics/API/Context.h"
 #include "sp/graphics/Renderer.h"
 
+#include "sp/platform/directx/DXContext.h"
+
 #include <GL/glew.h>
 #include <GL/wglew.h>
 
@@ -137,6 +139,8 @@ namespace sp {
 		m_Vsync = enabled;
 		if (graphics::API::Context::GetRenderAPI() == graphics::API::RenderAPI::OPENGL) {
 			wglSwapIntervalEXT(m_Vsync);
+		} else if (graphics::API::Context::GetRenderAPI() == graphics::API::RenderAPI::DIRECT3D) {
+			graphics::API::D3DContext::SetVsync(m_Vsync);
 		}
 	}
 


### PR DESCRIPTION
Window::SetVsync now enables/disables vsync for both opengl and direct3d. The direct3d implementation is maybe not the best, but it's the best I could come up with without rewriting anything. I'm open for any suggestions on improvement. 
