### PR TITLE
fixed signed/unsigned mismatch warning & remove implicit conversion engine wide

### DIFF
--- a/Sparky-core/src/sp/debug/DebugMenuAction.h
+++ b/Sparky-core/src/sp/debug/DebugMenuAction.h
@@ -19,7 +19,7 @@ namespace sp { namespace debug {
 
 	struct EmptyAction : public IAction
 	{
-		EmptyAction(const String& name) { this->name = name; }
+		explicit EmptyAction(const String& name) { this->name = name; }
 		void OnAction() override {}
 		String ToString() override { return name; }
 	};

--- a/Sparky-core/src/sp/entity/Entity.h
+++ b/Sparky-core/src/sp/entity/Entity.h
@@ -13,7 +13,7 @@ namespace sp { namespace entity {
 		std::vector<component::Component*> m_Components;
 	public:
 		Entity();
-		Entity(graphics::Mesh* mesh, const maths::mat4& transform = maths::mat4::Identity());
+		explicit Entity(graphics::Mesh* mesh, const maths::mat4& transform = maths::mat4::Identity());
 
 		void AddComponent(component::Component* component);
 

--- a/Sparky-core/src/sp/entity/component/MeshComponent.h
+++ b/Sparky-core/src/sp/entity/component/MeshComponent.h
@@ -12,7 +12,7 @@ namespace sp { namespace entity { namespace component {
 	public:
 		graphics::Mesh* mesh;
 	public:
-		MeshComponent(graphics::Mesh* mesh);
+		explicit MeshComponent(graphics::Mesh* mesh);
 
 		static ComponentType* GetStaticType()
 		{

--- a/Sparky-core/src/sp/entity/component/TransformComponent.h
+++ b/Sparky-core/src/sp/entity/component/TransformComponent.h
@@ -12,7 +12,7 @@ namespace sp { namespace entity { namespace component {
 	public:
 		maths::mat4 transform;
 	public:
-		TransformComponent(const maths::mat4& transform);
+		explicit TransformComponent(const maths::mat4& transform);
 
 		static ComponentType* GetStaticType()
 		{

--- a/Sparky-core/src/sp/events/Event.h
+++ b/Sparky-core/src/sp/events/Event.h
@@ -31,7 +31,7 @@ namespace sp { namespace events {
 		bool m_Handled;
 		Type m_Type;
 	protected:
-		Event(Type type);
+		explicit Event(Type type);
 	public:
 		inline Type GetType() const { return m_Type; }
 		inline bool IsHandled() const { return m_Handled; }

--- a/Sparky-core/src/sp/events/KeyEvent.h
+++ b/Sparky-core/src/sp/events/KeyEvent.h
@@ -38,7 +38,7 @@ namespace sp { namespace events {
 	class SP_API KeyReleasedEvent : public KeyEvent
 	{
 	public:
-		KeyReleasedEvent(int32 button);
+		explicit KeyReleasedEvent(int32 button);
 
 		inline static Type GetStaticType() { return Event::Type::KEY_RELEASED; }
 	};

--- a/Sparky-core/src/sp/graphics/API/Texture.h
+++ b/Sparky-core/src/sp/graphics/API/Texture.h
@@ -49,7 +49,7 @@ namespace sp { namespace graphics { namespace API {
 		{
 		}
 
-		TextureParameters(TextureFilter filter)
+		explicit TextureParameters(TextureFilter filter)
 			: format(TextureFormat::RGBA), filter(filter), wrap(TextureWrap::CLAMP)
 		{
 		}

--- a/Sparky-core/src/sp/graphics/BatchRenderer2D.cpp
+++ b/Sparky-core/src/sp/graphics/BatchRenderer2D.cpp
@@ -229,7 +229,7 @@ namespace sp { namespace graphics {
 		vec3 vertex = *m_TransformationBack * position;
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[0];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = textureSlot;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -238,7 +238,7 @@ namespace sp { namespace graphics {
 		vertex = *m_TransformationBack * vec3(position.x + size.x, position.y, position.z);
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[1];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = textureSlot;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -247,7 +247,7 @@ namespace sp { namespace graphics {
 		vertex = *m_TransformationBack * vec3(position.x + size.x, position.y + size.y, position.z);
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[2];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = textureSlot;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -256,7 +256,7 @@ namespace sp { namespace graphics {
 		vertex = *m_TransformationBack * vec3(position.x, position.y + size.y, position.z);
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[3];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = textureSlot;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -284,7 +284,7 @@ namespace sp { namespace graphics {
 		vec3 vertex = *m_TransformationBack * vec3(x0 + normal.x, y0 + normal.y, 0.0f);
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[0];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = ts;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -293,7 +293,7 @@ namespace sp { namespace graphics {
 		vertex = *m_TransformationBack * vec3(x1 + normal.x, y1 + normal.y, 0.0f);
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[1];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = ts;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -302,7 +302,7 @@ namespace sp { namespace graphics {
 		vertex = *m_TransformationBack * vec3(x1 - normal.x, y1 - normal.y, 0.0f);
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[2];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = ts;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -311,7 +311,7 @@ namespace sp { namespace graphics {
 		vertex = *m_TransformationBack * vec3(x0 - normal.x, y0 - normal.y, 0.0f);
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[3];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = ts;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -424,7 +424,7 @@ namespace sp { namespace graphics {
 		vec3 vertex = *m_TransformationBack * position;
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[0];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = ts;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -433,7 +433,7 @@ namespace sp { namespace graphics {
 		vertex = *m_TransformationBack * vec3(position.x + size.x, position.y, position.z);
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[1];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = ts;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -442,7 +442,7 @@ namespace sp { namespace graphics {
 		vertex = *m_TransformationBack * vec3(position.x + size.x, position.y + size.y, position.z);
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[2];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = ts;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;
@@ -451,7 +451,7 @@ namespace sp { namespace graphics {
 		vertex = *m_TransformationBack * vec3(position.x, position.y + size.y, position.z);
 		m_Buffer->vertex = vertex;
 		m_Buffer->uv = uv[3];
-		m_Buffer->mask_uv = maskTransform * vertex;
+		m_Buffer->mask_uv = vec2(maskTransform * vertex);
 		m_Buffer->tid = ts;
 		m_Buffer->mid = ms;
 		m_Buffer->color = color;

--- a/Sparky-core/src/sp/graphics/BatchRenderer2D.h
+++ b/Sparky-core/src/sp/graphics/BatchRenderer2D.h
@@ -66,7 +66,7 @@ namespace sp { namespace graphics {
 		Camera* m_Camera;
 	public:
 		BatchRenderer2D(uint width, uint height);
-		BatchRenderer2D(const maths::tvec2<uint>& screenSize);
+		explicit BatchRenderer2D(const maths::tvec2<uint>& screenSize);
 		~BatchRenderer2D();
 
 		void SetCamera(Camera* camera) override;

--- a/Sparky-core/src/sp/graphics/Font.cpp
+++ b/Sparky-core/src/sp/graphics/Font.cpp
@@ -65,7 +65,8 @@ namespace sp { namespace graphics {
 
 		float yo = 0.0f;
 		const maths::vec2& scale = m_Scale;
-		for (int i = 0; i < text.size(); i++)
+
+		for (size_t i = 0; i < text.size(); i++)
 		{
 			texture_glyph_t* glyph = texture_font_get_glyph(m_FTFont, text[i]);
 			SP_ASSERT(glyph);
@@ -84,7 +85,7 @@ namespace sp { namespace graphics {
 
 		float width = 0.0f;
 		const maths::vec2& scale = m_Scale;
-		for (int i = 0; i < text.size(); i++)
+		for (size_t i = 0; i < text.size(); i++)
 		{
 			texture_glyph_t* glyph = texture_font_get_glyph(m_FTFont, text[i]);
 			SP_ASSERT(glyph);
@@ -105,7 +106,7 @@ namespace sp { namespace graphics {
 		const maths::vec2& scale = m_Scale;
 		float min = 0.0f;
 		float max = 0.0f;
-		for (int i = 0; i < text.size(); i++)
+		for (size_t i = 0; i < text.size(); i++)
 		{
 			texture_glyph_t* glyph = texture_font_get_glyph(m_FTFont, text[i]);
 			SP_ASSERT(glyph);

--- a/Sparky-core/src/sp/graphics/Label.cpp
+++ b/Sparky-core/src/sp/graphics/Label.cpp
@@ -37,7 +37,7 @@ namespace sp { namespace graphics {
 
 	void Label::Submit(Renderer2D* renderer) const
 	{
-		renderer->DrawString(text, position, *m_Font, m_Color);
+		renderer->DrawString(text, sp::maths::vec2(position), *m_Font, m_Color);
 	}
 
 	void Label::ValidateFont(const String& name, int32 size)

--- a/Sparky-core/src/sp/graphics/Light.h
+++ b/Sparky-core/src/sp/graphics/Light.h
@@ -15,7 +15,7 @@ namespace sp { namespace graphics {
 		maths::vec3 lightVector;
 		float intensity;
 
-		Light(const maths::vec3& direction, float intensity = 1.0f, const maths::vec4& color = maths::vec4(1.0f));
+		explicit Light(const maths::vec3& direction, float intensity = 1.0f, const maths::vec4& color = maths::vec4(1.0f));
 	};
 
 } }

--- a/Sparky-core/src/sp/graphics/Material.h
+++ b/Sparky-core/src/sp/graphics/Material.h
@@ -41,7 +41,7 @@ namespace sp { namespace graphics {
 
 		int m_RenderFlags;
 	public:
-		Material(API::Shader* shader);
+		explicit Material(API::Shader* shader);
 		~Material();
 
 		void Bind();
@@ -104,7 +104,7 @@ namespace sp { namespace graphics {
 
 		int m_RenderFlags;
 	public:
-		MaterialInstance(Material* material);
+		explicit MaterialInstance(Material* material);
 
 		inline Material* GetMaterial() const { return m_Material; }
 

--- a/Sparky-core/src/sp/graphics/Model.h
+++ b/Sparky-core/src/sp/graphics/Model.h
@@ -15,7 +15,7 @@ namespace sp { namespace graphics {
 		Mesh* m_Mesh;
 	public:
 		// This eventually needs to be replaced by a global Asset Server.
-		Model(const String& path, MaterialInstance* materialInstance = nullptr);
+		explicit Model(const String& path, MaterialInstance* materialInstance = nullptr);
 		~Model();
 
 		void Render(Renderer3D& renderer) override;

--- a/Sparky-core/src/sp/graphics/PBRMaterial.h
+++ b/Sparky-core/src/sp/graphics/PBRMaterial.h
@@ -9,7 +9,7 @@ namespace sp { namespace graphics {
 	private:
 		static API::Texture2D* s_PreintegratedFG;
 	public:
-		PBRMaterial(API::Shader* shader);
+		explicit PBRMaterial(API::Shader* shader);
 		~PBRMaterial();
 
 		void SetEnviromentMap(API::TextureCube* texture);
@@ -35,7 +35,7 @@ namespace sp { namespace graphics {
 	class SP_API PBRMaterialInstance : public MaterialInstance
 	{
 	public:
-		PBRMaterialInstance(PBRMaterial* material);
+		explicit PBRMaterialInstance(PBRMaterial* material);
 
 		void SetEnviromentMap(API::TextureCube* texture);
 

--- a/Sparky-core/src/sp/graphics/Scene.h
+++ b/Sparky-core/src/sp/graphics/Scene.h
@@ -21,7 +21,7 @@ namespace sp { namespace graphics {
 		std::vector<LightSetup*> m_LightSetupStack;
 	public:
 		Scene();
-		Scene(Camera* camera);
+		explicit Scene(Camera* camera);
 		~Scene();
 
 		void Add(entity::Entity* entity);

--- a/Sparky-core/src/sp/graphics/Sprite.h
+++ b/Sparky-core/src/sp/graphics/Sprite.h
@@ -10,7 +10,7 @@ namespace sp { namespace graphics {
 		maths::vec3& position;
 		maths::vec2& size;
 	public:
-		Sprite(API::Texture2D* texture);
+		explicit Sprite(API::Texture2D* texture);
 		Sprite(float x, float y, API::Texture2D* texture);
 		Sprite(float x, float y, float width, float height, uint color);
 		Sprite(float x, float y, float width, float height, const maths::vec4& color);

--- a/Sparky-core/src/sp/graphics/camera/Camera.h
+++ b/Sparky-core/src/sp/graphics/camera/Camera.h
@@ -11,7 +11,7 @@ namespace sp { namespace graphics {
 		maths::mat4 m_ProjectionMatrix, m_ViewMatrix;
 		maths::vec3 m_Position, m_Rotation, m_FocalPoint;
 	public:
-		Camera(const maths::mat4& projectionMatrix);
+		explicit Camera(const maths::mat4& projectionMatrix);
 
 		virtual void Focus() { }
 		virtual void Update() { }

--- a/Sparky-core/src/sp/graphics/camera/FPSCamera.h
+++ b/Sparky-core/src/sp/graphics/camera/FPSCamera.h
@@ -12,7 +12,7 @@ namespace sp { namespace graphics {
 		float m_Pitch, m_Yaw;
 		bool m_MouseWasGrabbed;
 	public:
-		FPSCamera(const maths::mat4& projectionMatrix);
+		explicit FPSCamera(const maths::mat4& projectionMatrix);
 		~FPSCamera();
 		void Focus() override;
 		void Update() override;

--- a/Sparky-core/src/sp/graphics/camera/MayaCamera.h
+++ b/Sparky-core/src/sp/graphics/camera/MayaCamera.h
@@ -17,7 +17,7 @@ namespace sp { namespace graphics {
 
 		float m_Pitch, m_Yaw;
 	public:
-		MayaCamera(const maths::mat4& projectionMatrix);
+		explicit MayaCamera(const maths::mat4& projectionMatrix);
 		void Focus() override;
 		void Update() override;
 

--- a/Sparky-core/src/sp/graphics/layers/Group.h
+++ b/Sparky-core/src/sp/graphics/layers/Group.h
@@ -11,7 +11,7 @@ namespace sp { namespace graphics {
 		std::vector<Renderable2D*> m_Renderables;
 		maths::mat4 m_TransformationMatrix;
 	public:
-		Group(const maths::mat4& transform);
+		explicit Group(const maths::mat4& transform);
 		~Group();
 		void Add(Renderable2D* renderable);
 		void Submit(Renderer2D* renderer) const override;

--- a/Sparky-core/src/sp/graphics/layers/Layer2D.h
+++ b/Sparky-core/src/sp/graphics/layers/Layer2D.h
@@ -20,7 +20,7 @@ namespace sp { namespace graphics {
 		maths::mat4 m_ProjectionMatrix;
 	public:
 		// TODO: Replace Shader with Material
-		Layer2D(const maths::mat4& projectionMatrix);
+		explicit Layer2D(const maths::mat4& projectionMatrix);
 		virtual ~Layer2D();
 
 		virtual void Init();

--- a/Sparky-core/src/sp/graphics/layers/Layer3D.h
+++ b/Sparky-core/src/sp/graphics/layers/Layer3D.h
@@ -15,7 +15,7 @@ namespace sp { namespace graphics {
 		Scene* m_Scene;
 		Renderer3D* m_Renderer;
 	public:
-		Layer3D(Scene* scene, Renderer3D* renderer = new ForwardRenderer());
+		explicit Layer3D(Scene* scene, Renderer3D* renderer = new ForwardRenderer());
 		~Layer3D();
 
 		virtual void Init();

--- a/Sparky-core/src/sp/graphics/postfx/PostEffectsPass.h
+++ b/Sparky-core/src/sp/graphics/postfx/PostEffectsPass.h
@@ -11,7 +11,7 @@ namespace sp { namespace graphics {
 	private:
 		Material* m_Material;
 	public:
-		PostEffectsPass(API::Shader* shader);
+		explicit PostEffectsPass(API::Shader* shader);
 		~PostEffectsPass();
 
 		void RenderPass(Framebuffer* target);

--- a/Sparky-core/src/sp/graphics/shaders/ShaderUniform.h
+++ b/Sparky-core/src/sp/graphics/shaders/ShaderUniform.h
@@ -49,7 +49,7 @@ namespace sp { namespace graphics { namespace API {
 		uint m_Size;
 		uint m_Offset;
 	public:
-		ShaderStruct(const String& name)
+		explicit ShaderStruct(const String& name)
 			: m_Name(name), m_Size(0), m_Offset(0)
 		{
 		}

--- a/Sparky-core/src/sp/graphics/ui/Slider.h
+++ b/Sparky-core/src/sp/graphics/ui/Slider.h
@@ -24,8 +24,8 @@ namespace sp { namespace graphics { namespace ui {
 		ValueChangedCallback m_Callback;
 		bool m_Vertical;
 	public:
-		Slider(const maths::Rectangle& bounds, bool vertical = false);
-		Slider(const maths::Rectangle& bounds, float value = 0.0f, const ValueChangedCallback& callback = &Slider::NoCallback, bool vertical = false);
+		explicit Slider(const maths::Rectangle& bounds, bool vertical = false);
+		explicit Slider(const maths::Rectangle& bounds, float value = 0.0f, const ValueChangedCallback& callback = &Slider::NoCallback, bool vertical = false);
 
 		bool OnMousePressed(events::MousePressedEvent& e) override;
 		bool OnMouseReleased(events::MouseReleasedEvent& e) override;

--- a/Sparky-core/src/sp/graphics/ui/Widget.h
+++ b/Sparky-core/src/sp/graphics/ui/Widget.h
@@ -18,7 +18,7 @@ namespace sp { namespace graphics { namespace ui {
 	private:
 		Widget() {}
 	protected:
-		Widget(const maths::Rectangle& bounds);
+		explicit Widget(const maths::Rectangle& bounds);
 	public:
 		virtual bool OnMousePressed(events::MousePressedEvent& e);
 		virtual bool OnMouseReleased(events::MouseReleasedEvent& e);

--- a/Sparky-core/src/sp/maths/Quaternion.h
+++ b/Sparky-core/src/sp/maths/Quaternion.h
@@ -14,7 +14,7 @@ namespace sp { namespace maths {
 		Quaternion(const Quaternion& quaternion);
 		Quaternion(float x, float y, float z, float w);
 		Quaternion(const vec3& xyz, float w);
-		Quaternion(const vec4& vec);
+		explicit Quaternion(const vec4& vec);
 		Quaternion(float scalar);
 
 		Quaternion& operator=(const Quaternion& quat);

--- a/Sparky-core/src/sp/maths/mat4.h
+++ b/Sparky-core/src/sp/maths/mat4.h
@@ -21,8 +21,8 @@ namespace sp { namespace maths {
 		};
 
 		mat4();
-		mat4(float diagonal);
-		mat4(float* elements);
+		explicit mat4(float diagonal);
+		explicit mat4(float* elements);
 		mat4(const vec4& row0, const vec4& row1, const vec4& row2, const vec4& row3);
 
 		static mat4 Identity();

--- a/Sparky-core/src/sp/maths/vec2.h
+++ b/Sparky-core/src/sp/maths/vec2.h
@@ -13,9 +13,9 @@ namespace sp { namespace maths {
 		float x, y;
 
 		vec2();
-		vec2(float scalar);
+		explicit vec2(float scalar);
 		vec2(float x, float y);
-		vec2(const vec3& vector);
+		explicit vec2(const vec3& vector);
 
 		vec2& Add(const vec2& other);
 		vec2& Subtract(const vec2& other);

--- a/Sparky-core/src/sp/maths/vec3.h
+++ b/Sparky-core/src/sp/maths/vec3.h
@@ -15,9 +15,9 @@ namespace sp { namespace maths {
 		float x, y, z;
 
 		vec3();
-		vec3(float scalar);
+		explicit vec3(float scalar);
 		vec3(float x, float y, float z);
-		vec3(const vec2& other);
+		explicit vec3(const vec2& other);
 		vec3(float x, float y);
 
 		static vec3 Up();

--- a/Sparky-core/src/sp/maths/vec4.h
+++ b/Sparky-core/src/sp/maths/vec4.h
@@ -14,7 +14,7 @@ namespace sp { namespace maths {
 		float x, y, z, w;
 
 		vec4() = default;
-		vec4(float scalar);
+		explicit vec4(float scalar);
 		vec4(float x, float y, float z, float w);
 		vec4(const vec3& xyz, float w);
 

--- a/Sparky-core/src/sp/platform/directx/DXVertexBuffer.h
+++ b/Sparky-core/src/sp/platform/directx/DXVertexBuffer.h
@@ -17,7 +17,7 @@ namespace sp { namespace graphics { namespace API {
 		uint m_Size;
 		BufferLayout m_Layout;
 	public:
-		D3DVertexBuffer(BufferUsage usage);
+		explicit D3DVertexBuffer(BufferUsage usage);
 		~D3DVertexBuffer();
 
 		void Resize(uint size) override;

--- a/Sparky-core/src/sp/platform/opengl/GLVertexBuffer.h
+++ b/Sparky-core/src/sp/platform/opengl/GLVertexBuffer.h
@@ -13,7 +13,7 @@ namespace sp { namespace graphics { namespace API {
 		uint m_Size;
 		BufferLayout m_Layout;
 	public:
-		GLVertexBuffer(BufferUsage usage);
+		explicit GLVertexBuffer(BufferUsage usage);
 		~GLVertexBuffer();
 
 		void Resize(uint size) override;


### PR DESCRIPTION
commit 1[fixed signed/unsigned mismatch warning]:self explanatory
commit 2[remove implicit conversion engine wide]:
implicit conversion can cause ambiguity in code to avoid this I added the explicit keyword to constructors with one argument or constructors that can act as one argument constructors because of default parameters. 
