### PR TITLE
fixed a bug in Orthographic matrix.

### DIFF
--- a/Sparky-core/src/sp/maths/mat4.cpp
+++ b/Sparky-core/src/sp/maths/mat4.cpp
@@ -238,7 +238,7 @@ namespace sp { namespace maths {
 
 		result.elements[3 + 0 * 4] = (left + right) / (left - right);
 		result.elements[3 + 1 * 4] = (bottom + top) / (bottom - top);
-		result.elements[3 + 2 * 4] = (far + near) / (far - near);
+		result.elements[3 + 2 * 4] = (far + near) / (near - far);
 
 		return result;
 	}


### PR DESCRIPTION
Judging from this picture: https://www.safaribooksonline.com/library/view/opengl-es-2/9781941222560/images/AspectRatio/OrthographicMatrixDefinition.png, I believe you accidentally flipped the sign at the line I edited.