### PR TITLE
Edit ResolveUniform() function

### DIFF
--- a/Sparky-core/src/sp/platform/opengl/GLShader.cpp
+++ b/Sparky-core/src/sp/platform/opengl/GLShader.cpp
@@ -338,6 +338,7 @@ namespace sp { namespace graphics { namespace API {
 					uniform->m_Location = GetUniformLocation(uniform->m_Name);
 				}
 			}
+		} // <- add an misplaced closing bracket here;
 
 			for (uint i = 0; i < m_PSUniformBuffers.size(); i++)
 			{
@@ -437,7 +438,7 @@ namespace sp { namespace graphics { namespace API {
 				}
 			}
 			Unbind();
-		}
+		// } <- remove this closing bracket;
 	}
 
 	void GLShader::ValidateUniforms()


### PR DESCRIPTION
Due to a misplaced closing bracket, the rest of ResolveUniform() function's code is placed inside the first loop, even Unbind(), which may lead to false behavior.
Instead of reformat the whole function's code (spacing, indent, etc..) I just remove and replace that bracket to show that the rest of the code (other than the misplaced bracket) remain unchanged.